### PR TITLE
Add Dracula Colors for Powerline-Evil Faces

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -276,15 +276,7 @@
    `(enh-ruby-heredoc-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-regexp-delimiter-face ((,class (:foreground ,str))))
-   `(which-func ((,class (:inherit ,font-lock-function-name-face))))
-   `(powerline-evil-base-face ((t (:foreground ,bg2))))
-   `(powerline-evil-normal-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-6))))
-   `(powerline-evil-insert-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-2))))
-   `(powerline-evil-visual-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-5))))
-   `(powerline-evil-operator-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-4))))
-   `(powerline-evil-replace-face ((,class (:inherit powerline-evil-base-face :background "#ff5555"))))
-   `(powerline-evil-motion-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-3))))
-   `(powerline-evil-emacs-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-7))))))
+   `(which-func ((,class (:inherit ,font-lock-function-name-face))))))
 
 ;;;###autoload
 (when load-file-name

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -274,7 +274,15 @@
    `(enh-ruby-heredoc-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-regexp-delimiter-face ((,class (:foreground ,str))))
-   `(which-func ((,class (:inherit ,font-lock-function-name-face))))))
+   `(which-func ((,class (:inherit ,font-lock-function-name-face))))
+   `(powerline-evil-base-face ((t (:foreground ,bg2))))
+   `(powerline-evil-normal-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-6))))
+   `(powerline-evil-insert-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-2))))
+   `(powerline-evil-visual-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-5))))
+   `(powerline-evil-operator-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-4))))
+   `(powerline-evil-replace-face ((,class (:inherit powerline-evil-base-face :background "#ff5555"))))
+   `(powerline-evil-motion-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-3))))
+   `(powerline-evil-emacs-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-7))))))
 
 ;;;###autoload
 (when load-file-name

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -274,7 +274,7 @@
    `(enh-ruby-heredoc-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-regexp-delimiter-face ((,class (:foreground ,str))))
-   `(which-func ((,class (:inherit ,font-lock-function-name-face))))))
+   `(which-func ((,class (:inherit ,font-lock-function-name-face))))
    `(powerline-evil-normal-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-6))))
    `(powerline-evil-insert-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-2))))
    `(powerline-evil-visual-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-5))))

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -275,6 +275,14 @@
    `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-regexp-delimiter-face ((,class (:foreground ,str))))
    `(which-func ((,class (:inherit ,font-lock-function-name-face))))))
+   `(powerline-evil-normal-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-6))))
+   `(powerline-evil-insert-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-2))))
+   `(powerline-evil-visual-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-5))))
+   `(powerline-evil-operator-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-4))))
+   `(powerline-evil-replace-face ((,class (:inherit powerline-evil-base-face :background "#ff5555"))))
+   `(powerline-evil-motion-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-3))))
+   `(powerline-evil-emacs-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-7))))))
+
 
 ;;;###autoload
 (when load-file-name

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -18,14 +18,12 @@
 
 (deftheme dracula)
 
-(if (display-graphic-p) (setq bg1 "#282a36") (setq bg1 "#000000"))
-
 (let ((class '((class color) (min-colors 89)))
       (fg1 "#f8f8f2")
       (fg2 "#e2e2dc")
       (fg3 "#ccccc7")
       (fg4 "#b6b6b2")
-      ;; (bg1 "#282a36")
+      (bg1 "#282a36")
       (bg2 "#373844")
       (bg3 "#464752")
       (bg4 "#565761")
@@ -51,7 +49,7 @@
       (rainbow-8 "#0189cc")
       (eph-verbatim "#f1fa8c")
       (eph-code "#ff79c6"))
-  
+
   (custom-theme-set-faces
    'dracula
    `(default ((,class (:background ,bg1 :foreground ,fg1))))

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -18,12 +18,14 @@
 
 (deftheme dracula)
 
+(if (display-graphic-p) (setq bg1 "#282a36") (setq bg1 "#000000"))
+
 (let ((class '((class color) (min-colors 89)))
       (fg1 "#f8f8f2")
       (fg2 "#e2e2dc")
       (fg3 "#ccccc7")
       (fg4 "#b6b6b2")
-      (bg1 "#282a36")
+      ;; (bg1 "#282a36")
       (bg2 "#373844")
       (bg3 "#464752")
       (bg4 "#565761")
@@ -49,7 +51,7 @@
       (rainbow-8 "#0189cc")
       (eph-verbatim "#f1fa8c")
       (eph-code "#ff79c6"))
-
+  
   (custom-theme-set-faces
    'dracula
    `(default ((,class (:background ,bg1 :foreground ,fg1))))


### PR DESCRIPTION
Add Dracula Theme colors for the Powerline-Evil mode faces.
Foreground = bg2
Normal = green (rainbow-6)
Insert = blue (rainbow-2)
Visual = orange (rainbow-5)
Operator = pink (rainbow-4)
Replace = red (#ff5555)
Motion = purple (rainbow-3)
Emacs = yellow (rainbow-7)
