### PR TITLE
Fix typo for company-tooltip-annotation

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -246,7 +246,7 @@
    `(company-scrollbar-bg ((,class (:background ,bg3))))
    `(company-scrollbar-fg ((,class (:foreground ,keyword))))
    `(company-tooltip ((,class (:foreground ,fg2 :background ,bg1 :bold t))))
-   `(company-tooltop-annotation ((,class (:foreground ,const))))
+   `(company-tooltip-annotation ((,class (:foreground ,const))))
    `(company-tooltip-common ((,class ( :foreground ,fg3))))
    `(company-tooltip-common-selection ((,class (:foreground ,str))))
    `(company-tooltip-mouse ((,class (:inherit highlight))))


### PR DESCRIPTION
Fixed a typo for company-tooltip-annotation, it was written as company-tool**top**-annotation.
