### PR TITLE
Add Powerline Evil Colors

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -274,7 +274,17 @@
    `(enh-ruby-heredoc-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))
    `(enh-ruby-regexp-delimiter-face ((,class (:foreground ,str))))
-   `(which-func ((,class (:inherit ,font-lock-function-name-face))))))
+   `(which-func ((,class (:inherit ,font-lock-function-name-face))))
+   `(powerline-evil-base-face ((t (:foreground ,bg2))))
+   `(powerline-evil-normal-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-6))))
+   `(powerline-evil-insert-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-2))))
+   `(powerline-evil-visual-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-5))))
+   `(powerline-evil-operator-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-4))))
+   `(powerline-evil-replace-face ((,class (:inherit powerline-evil-base-face :background "#ff5555"))))
+   `(powerline-evil-motion-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-3))))
+   `(powerline-evil-emacs-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-7))))))
+   
+
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
Powerline Evil is an emacs package that adds an indicator to the Emacs
modeline. The color of the indicator changes depending on which VI mode
emacs is in (green for Normal mode, Orange for Visual, etc). This commit
adds settings for these indicators to dracula-theme.el, so that they
use the Dracula versions of green, blue, orange, etc. instead of the
generic colors used by powerline-evil.el.

Here is what the new version looks like compared with the current one
![powerline-evil-colors](https://cloud.githubusercontent.com/assets/7518085/16289505/7b5db6e6-38aa-11e6-91f0-566a25d6ccfa.png)
