### PR TITLE
Fix Terminal Background Color

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -18,12 +18,13 @@
 
 (deftheme dracula)
 
+(if (display-graphic-p) (setq bg1 "#282a36") (setq bg1 nil))
+
 (let ((class '((class color) (min-colors 89)))
       (fg1 "#f8f8f2")
       (fg2 "#e2e2dc")
       (fg3 "#ccccc7")
       (fg4 "#b6b6b2")
-      (bg1 "#282a36")
       (bg2 "#373844")
       (bg3 "#464752")
       (bg4 "#565761")


### PR DESCRIPTION
When using Dracula theme in terminal the result is a blue background that does not look good:
<img width="962" alt="c4aa5592-bb14-11e6-8133-04c35697a6c3" src="https://cloud.githubusercontent.com/assets/7518085/23284430/507eb72a-f9e0-11e6-8590-2f91439c1bf0.png">

By setting the background color to nil when emacs is run in the terminal, the normal color of the terminal background will be used. If the user is using Dracula theme colors in their terminal the proper color will show:
![screen shot 2017-02-23 at 3 50 50 pm](https://cloud.githubusercontent.com/assets/7518085/23284416/2a85867a-f9e0-11e6-8721-4e1c1f423c16.png)