### PR TITLE
Set background color to black on non-graphical startup

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -18,7 +18,7 @@
 
 (deftheme dracula)
 
-(if (display-graphic-p) (setq bg1 "#282a36") (setq bg1 nil))
+(if (display-graphic-p) (setq bg1 "#282a36") (setq bg1 "#000000"))
 
 (let ((class '((class color) (min-colors 89)))
       (fg1 "#f8f8f2")


### PR DESCRIPTION
This is a temporary fix to the display issues described in #21. This will make
the background appear black however instead of the ideal #282a36