### PR TITLE
Fix non-graphical color switch

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -18,13 +18,12 @@
 
 (deftheme dracula)
 
-(if (display-graphic-p) (setq bg1 "#282a36") (setq bg1 "#000000"))
-
 (let ((class '((class color) (min-colors 89)))
       (fg1 "#f8f8f2")
       (fg2 "#e2e2dc")
       (fg3 "#ccccc7")
       (fg4 "#b6b6b2")
+      (bg1 "#282a36")
       (bg2 "#373844")
       (bg3 "#464752")
       (bg4 "#565761")
@@ -56,7 +55,8 @@
    'dracula
    ;; default
    `(cursor ((,class (:background ,fg3))))
-   `(default ((,class (:background ,bg1 :foreground ,fg1))))
+   `(default ((((type nil)) (:background "#000000" :foreground ,fg1))
+              (,class (:background ,bg1 :foreground ,fg1))))
    `(default-italic ((,class (:italic t))))
    `(ffap ((,class (:foreground ,fg4))))
    `(fringe ((,class (:background ,bg1 :foreground ,fg4))))


### PR DESCRIPTION
`(display-graphic-p)` will evaluate to nil when starting Emacs in daemon mode.
Instead, we now use the attribute switch system provided by custom.el, which
apply definitions when a frame is created and will do the right thing when
running Emacs daemon.

Fixes #23