### PR TITLE
bring Emacs support closer to recent vs.code changes

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -84,9 +84,6 @@
    `(font-lock-negation-char-face ((,class (:foreground ,const))))
    `(font-lock-number-face ((,class (:foreground ,str))))
    `(font-lock-operator-face ((,class (:foreground , keyword))))
-   ;; Haskell Mode uses variable face by default so why have to override this directly
-   `(haskell-operator-face ((,class (:foreground , rainbow-4))))
-   `(haskell-constructor-face ((,class (:foreground , rainbow-3))))
    `(font-lock-preprocessor-face ((,class (:foreground , builtin))))
    `(font-lock-reference-face ((,class (:foreground ,const))))
    `(font-lock-regexp-grouping-backslash ((,class (:foreground ,rainbow-2))))
@@ -160,6 +157,9 @@
    `(gnus-summary-normal-ticked ((,class (:foreground ,keyword :weight light))))
    `(gnus-summary-normal-unread ((,class (:foreground ,comment :weight normal))))
    `(gnus-summary-selected ((,class (:inverse-video t))))
+   ;; haskell-mode
+   `(haskell-operator-face ((,class (:foreground , rainbow-4))))
+   `(haskell-constructor-face ((,class (:foreground , rainbow-3))))
    ;; helm
    `(helm-bookmark-w3m ((,class (:foreground ,type))))
    `(helm-buffer-not-saved ((,class (:foreground ,type :background ,bg1))))

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -75,15 +75,24 @@
    `(whitespace-trailing ((,class :inherit trailing-whitespace)))
    ;; syntax
    `(font-lock-builtin-face ((,class (:foreground ,builtin))))
+   `(font-lock-comment-delimiter-face ((,class (:foreground ,comment))))
    `(font-lock-comment-face ((,class (:foreground ,comment))))
    `(font-lock-constant-face ((,class (:foreground ,const))))
    `(font-lock-doc-face ((,class (:foreground ,comment))))
    `(font-lock-function-name-face ((,class (:foreground ,func :bold t))))
    `(font-lock-keyword-face ((,class (:bold ,class :foreground ,keyword))))
    `(font-lock-negation-char-face ((,class (:foreground ,const))))
+   `(font-lock-number-face ((,class (:foreground ,str))))
+   `(font-lock-operator-face ((,class (:foreground , keyword))))
+   ;; Haskell Mode uses variable face by default so why have to override this directly
+   `(haskell-operator-face ((,class (:foreground , keyword))))
+   `(font-lock-preprocessor-face ((,class (:foreground , builtin))))
    `(font-lock-reference-face ((,class (:foreground ,const))))
+   `(font-lock-regexp-grouping-backslash ((,class (:foreground ,rainbow-2))))
+   `(font-lock-regexp-grouping-construct ((,class (:foreground ,rainbow-3))))
    `(font-lock-string-face ((,class (:foreground ,str))))
-   `(font-lock-type-face ((,class (:foreground ,type ))))
+   ;; make type cyan as in the last vs.code theme
+   `(font-lock-type-face ((,class (:foreground , "#00ffff"))))
    `(font-lock-variable-name-face ((,class (:foreground ,var))))
    `(font-lock-warning-face ((,class (:foreground ,warning :background ,bg2))))
    ;; auto-complete

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -48,7 +48,8 @@
       (rainbow-8 "#0189cc")
       (rainbow-9 "#ff5555")
       (eph-verbatim "#f1fa8c")
-      (eph-code "#ff79c6"))
+      (eph-code "#ff79c6")
+      (type-name "00ffff"))
 
   (custom-theme-set-faces
    'dracula
@@ -90,7 +91,7 @@
    `(font-lock-regexp-grouping-construct ((,class (:foreground ,rainbow-3))))
    `(font-lock-string-face ((,class (:foreground ,str))))
    ;; make type cyan as in the last vs.code theme
-   `(font-lock-type-face ((,class (:foreground , "#00ffff"))))
+   `(font-lock-type-face ((,class (:foreground , type-name))))
    `(font-lock-variable-name-face ((,class (:foreground ,var))))
    `(font-lock-warning-face ((,class (:foreground ,warning :background ,bg2))))
    ;; auto-complete

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -85,7 +85,8 @@
    `(font-lock-number-face ((,class (:foreground ,str))))
    `(font-lock-operator-face ((,class (:foreground , keyword))))
    ;; Haskell Mode uses variable face by default so why have to override this directly
-   `(haskell-operator-face ((,class (:foreground , keyword))))
+   `(haskell-operator-face ((,class (:foreground , rainbow-4))))
+   `(haskell-constructor-face ((,class (:foreground , rainbow-3))))
    `(font-lock-preprocessor-face ((,class (:foreground , builtin))))
    `(font-lock-reference-face ((,class (:foreground ,const))))
    `(font-lock-regexp-grouping-backslash ((,class (:foreground ,rainbow-2))))


### PR DESCRIPTION
added some missing font-lock faces, overrode operators for Haskell-mode

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.