### PR TITLE
Tweaked powerline colours

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -27,6 +27,7 @@
       (bg3 "#464752")
       (bg4 "#565761")
       (bg5 "#44475a")
+      (bg6 "#b45bcf")
       (key2 "#0189cc")
       (key3 "#ff79c6")
       (builtin "#ffb86c")
@@ -73,6 +74,7 @@
    `(vertical-border ((,class (:foreground ,bg2))))
    `(warning ((,class (:foreground ,warning))))
    `(whitespace-trailing ((,class :inherit trailing-whitespace)))
+   `(header-line ((,class :background ,bg1)))
    ;; syntax
    `(font-lock-builtin-face ((,class (:foreground ,builtin))))
    `(font-lock-comment-face ((,class (:foreground ,comment))))
@@ -288,6 +290,10 @@
    `(powerline-evil-operator-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-4))))
    `(powerline-evil-replace-face ((,class (:inherit powerline-evil-base-face :background "#ff5555"))))
    `(powerline-evil-visual-face ((,class (:inherit powerline-evil-base-face :background ,rainbow-5))))
+   `(powerline-active1 ((,class (:background ,bg6 :foreground ,fg1))))
+   `(powerline-active2 ((,class (:background ,bg6 :foreground ,fg1))))
+   `(powerline-inactive1 ((,class (:background ,bg3 :foreground ,fg1))))
+   `(powerline-inactive2 ((,class (:background ,bg3 :foreground ,fg1))))
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((,class :foreground ,rainbow-1)))
    `(rainbow-delimiters-depth-2-face ((,class :foreground ,rainbow-2)))


### PR DESCRIPTION
Tweaked powerline colours as discussed in https://github.com/dracula/emacs/issues/20.

**Before:**
![screen shot 2017-08-22 at 01 14 04](https://user-images.githubusercontent.com/11179011/29541874-509ebc62-86d7-11e7-9185-034a9e2fe39b.png)
![screen shot 2017-08-22 at 01 14 09](https://user-images.githubusercontent.com/11179011/29541873-509c5580-86d7-11e7-8996-965b3e437d96.png)

**After:**
![screen shot 2017-08-22 at 01 12 37](https://user-images.githubusercontent.com/11179011/29541883-5cec0a38-86d7-11e7-8741-4b12fe3f3d19.png)
![screen shot 2017-08-22 at 01 12 53](https://user-images.githubusercontent.com/11179011/29541882-5ce4775a-86d7-11e7-85f8-8b9b1c51f616.png)
