### PR TITLE
Ensure that the modeline is distinct on inactive windows

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -224,8 +224,8 @@
                (magit-section-heading :foreground ,keyword :weight bold)
                (magit-section-highlight :background ,bg2)
                ;; mode-line
-               (mode-line :foreground nil :background ,bg3 :box ,bg3)
-               (mode-line-inactive :foreground ,fg1 :background ,bg1 :box ,bg1)
+               (mode-line :foreground nil :background ,bg5 :box ,bg5)
+               (mode-line-inactive :foreground ,fg1 :background ,bg2 :box ,bg2)
                ;; mu4e
                (mu4e-cited-1-face :foreground ,fg2)
                (mu4e-cited-7-face :foreground ,fg3)


### PR DESCRIPTION
Otherwise, it's hard to see the edge of windows when the frame is
split.

Before:

![dracula_before](https://user-images.githubusercontent.com/70800/39594269-1ca7348e-4f04-11e8-9127-829cf326ffbb.png)

After:

![dracula_after](https://user-images.githubusercontent.com/70800/39594275-20b932fc-4f04-11e8-908e-7cdd7a807ad5.png)