### PR TITLE
Update term colors to better represent ANSI colors

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -317,13 +317,13 @@
                ;; term
                (term :foreground ,fg1 :background ,bg1)
                (term-color-black :foreground ,bg3 :background ,bg3)
-               (term-color-blue :foreground ,func :background ,func)
-               (term-color-cyan :foreground ,str :background ,str)
-               (term-color-green :foreground ,type :background ,bg3)
+               (term-color-blue :foreground ,type :background ,func)
+               (term-color-cyan :foreground ,const :background ,const)
+               (term-color-green :foreground ,func :background ,bg3)
                (term-color-magenta :foreground ,builtin :background ,builtin)
                (term-color-red :foreground ,keyword :background ,bg3)
                (term-color-white :foreground ,fg2 :background ,fg2)
-               (term-color-yellow :foreground ,var :background ,var)
+               (term-color-yellow :foreground ,str :background ,var)
                ;; undo-tree
                (undo-tree-visualizer-current-face :foreground ,builtin)
                (undo-tree-visualizer-default-face :foreground ,fg2)


### PR DESCRIPTION
Previously, green wasn't green, yellow wasn't yellow, etc. This changeset more closely aligns the Dracula theme with the standard ANSI definitions which I feel like at least, what most users would expect.

## Before

<img width="656" alt="screen shot 2018-05-21 at 12 31 20 pm" src="https://user-images.githubusercontent.com/877908/40320910-e9b7361c-5cf2-11e8-83aa-9c948c8ac462.png">


## After

<img width="695" alt="screen shot 2018-05-21 at 11 26 56 am" src="https://user-images.githubusercontent.com/877908/40318366-fe9f2002-5ce9-11e8-978d-a2bee624c4bf.png">
