### PR TITLE
Use 256-color remapping only when needed

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -428,10 +428,10 @@
                                                    (eval `(backquote ,spec)))))
              (cl-loop for (face . spec) in faces
                       collect `(,face
-                                ((((type tty))
-                                  ,(expand-for-tty spec))
-                                 (((type graphic))
-                                  ,(expand-for-graphic spec)))))))))
+                                ((((min-colors 16777216))
+                                  ,(expand-for-graphic spec))
+                                 (t
+                                  ,(expand-for-tty spec)))))))))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
Emacs 26.1 now supports 24-bit color terminals, so we want to base the fallback
test on ‘min-colors’, not ‘type’.