### PR TITLE
Support the new display-line-numbers mode

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -63,6 +63,7 @@
                (lazy-highlight :foreground ,fg2 :background ,bg3)
                (link :foreground ,const :underline t)
                (linum :slant italic :foreground ,bg4 :background ,bg1)
+               (line-number :slant italic :foreground ,bg4 :background ,bg1)
                (minibuffer-prompt :bold t :foreground ,keyword)
                (region :background ,str :foreground ,bg1)
                (show-paren-match-face :background ,warning)


### PR DESCRIPTION
Starting with Emacs 26.1, linum-mode is sort-of deprecated and users are advised to move to the native solution.

Here is the current line number display when using display-line-numbers-mode

![without](https://user-images.githubusercontent.com/349239/63970944-b238eb00-caa5-11e9-8731-183f6205c080.png)

And here is how it is displayed when this PR is applied:

![with](https://user-images.githubusercontent.com/349239/63970945-b533db80-caa5-11e9-8828-d10e530f4109.png)