### PR TITLE
Add faces hardcoded by lsp-ui

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -375,11 +375,10 @@ read it before opening a new issue about your will.")
                (lsp-ui-peek-list :background ,bg2)
                (lsp-ui-peek-filename :foreground ,dracula-pink :weight bold)
                (lsp-ui-peek-line-number :foreground ,dracula-fg)
-               (lsp-ui-peek-highlight :background ,bg4 :foreground ,fg4
-                                      :distant-foreground ,dracula-bg)
+               (lsp-ui-peek-highlight :inherit highlight :distant-foreground ,dracula-bg)
                (lsp-ui-peek-header :background ,bg3 :foreground ,fg3, :weight bold)
                (lsp-ui-peek-footer :inherit lsp-ui-peek-header)
-               (lsp-ui-peek-selection :background ,bg4 :foreground ,fg4)
+               (lsp-ui-peek-selection :inherit match)
                (lsp-ui-sideline-symbol :foreground ,fg4 :box (:line-width -1 :color ,fg4) :height 0.99)
                (lsp-ui-sideline-current-symbol :foreground ,dracula-fg :weight ultra-bold
                                                :box (:line-width -1 :color dracula-fg) :height 0.99)

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -380,6 +380,13 @@ read it before opening a new issue about your will.")
                (lsp-ui-peek-header :background ,bg3 :foreground ,fg3, :weight bold)
                (lsp-ui-peek-footer :inherit lsp-ui-peek-header)
                (lsp-ui-peek-selection :background ,bg4 :foreground ,fg4)
+               (lsp-ui-sideline-symbol :foreground ,fg4 :box (:line-width -1 :color ,fg4) :height 0.99)
+               (lsp-ui-sideline-current-symbol :foreground ,dracula-fg :weight ultra-bold
+                                               :box (:line-width -1 :color dracula-fg) :height 0.99)
+               (lsp-ui-sideline-code-action :foreground ,dracula-yellow)
+               (lsp-ui-sideline-symbol-info :slant italic :height 0.99)
+               (lsp-ui-doc-background :background ,dracula-bg)
+               (lsp-ui-doc-header :foreground ,dracula-bg :background ,dracula-cyan)
                ;; magit
                (magit-branch-local :foreground ,dracula-cyan)
                (magit-branch-remote :foreground ,dracula-green)

--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -370,6 +370,16 @@ read it before opening a new issue about your will.")
                (js3-instance-member-face :foreground ,dracula-cyan)
                (js3-jsdoc-tag-face :foreground ,dracula-pink)
                (js3-warning-face :underline ,dracula-pink)
+               ;; lsp
+               (lsp-ui-peek-peek :background ,dracula-bg)
+               (lsp-ui-peek-list :background ,bg2)
+               (lsp-ui-peek-filename :foreground ,dracula-pink :weight bold)
+               (lsp-ui-peek-line-number :foreground ,dracula-fg)
+               (lsp-ui-peek-highlight :background ,bg4 :foreground ,fg4
+                                      :distant-foreground ,dracula-bg)
+               (lsp-ui-peek-header :background ,bg3 :foreground ,fg3, :weight bold)
+               (lsp-ui-peek-footer :inherit lsp-ui-peek-header)
+               (lsp-ui-peek-selection :background ,bg4 :foreground ,fg4)
                ;; magit
                (magit-branch-local :foreground ,dracula-cyan)
                (magit-branch-remote :foreground ,dracula-green)


### PR DESCRIPTION
![Screenshot from 2020-05-09 00-29-27](https://user-images.githubusercontent.com/61111279/81421295-39d60e00-918c-11ea-909f-d3d48ce9667b.png)

Add faces defined by [lsp-ui-peek.el](https://github.com/emacs-lsp/lsp-ui/blob/master/lsp-ui-peek.el) using existing colors.

Some faces defined in other files are not added yet.

This partially addresses #64.