### PR TITLE
Neo-tree colors, fixes #42

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -469,6 +469,10 @@ read it before opening a new issue about your will.")
                (mu4e-cited-3-face :foreground ,dracula-comment)
                (mu4e-cited-4-face :foreground ,fg2)
                (mu4e-cited-5-face :foreground ,fg3)
+               ;; neo-tree
+               (neo-file-link-face :foreground ,fg1)
+               (neo-root-dir-face :bold t :foreground ,dracula-purple)
+               (neo-dir-link-face :foreground ,dracula-purple)
                ;; org
                (org-agenda-date :foreground ,dracula-cyan :underline nil)
                (org-agenda-dimmed-todo-face :foreground ,dracula-comment)


### PR DESCRIPTION
Original screenshot: https://github.com/dracula/emacs/issues/42
Screenshot after (in 256 terminal mode):
<img width="1792" alt="Screenshot 2020-05-12 at 08 29 35" src="https://user-images.githubusercontent.com/122018/81642079-37ddaa80-942b-11ea-911b-3ad7c8b77e5e.png">
