### PR TITLE
Exchange the mode-line foreground

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -535,13 +535,13 @@ read it before opening a new issue about your will.")
                           :box ,dracula-current :inverse-video nil
                           ,@(if dracula-alternate-mode-line-and-minibuffer
                                 (list :foreground fg3)
-                              (list :foreground "unspecified-fg")))
+                              (list :foreground dracula-fg)))
                (mode-line-inactive
                 :inverse-video nil
                 ,@(if dracula-alternate-mode-line-and-minibuffer
                       (list :foreground dracula-comment :background dracula-bg
                             :box dracula-bg)
-                    (list :foreground dracula-fg :background bg2 :box bg2)))
+                    (list :foreground "unspecified-fg" :background bg2 :box bg2)))
                ;; mu4e
                (mu4e-unread-face :foreground ,dracula-pink :weight normal)
                (mu4e-view-url-number-face :foreground ,dracula-purple)


### PR DESCRIPTION
The default active mode-line foreground is darker than the
inactive mode-line, which may make it difficult for users to
distinguish the current active buffer. After I exchanged these
two values, it seems that the situation has been solved.

Here is the actual effort:

The left buffer is the current active buffer.

- before
<img width="1680" alt="before" src="https://user-images.githubusercontent.com/25452934/139015658-d969d198-1781-40a0-a276-d969493864fa.png">

- afte
<img width="1680" alt="after" src="https://user-images.githubusercontent.com/25452934/139015676-bc23f7a9-fb32-41c6-9ae3-a9ade558662b.png">
