### PR TITLE
Support header-line

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -561,6 +561,9 @@ read it before opening a new issue about your will.")
                       (list :foreground dracula-comment :box dracula-bg)
                     (list :foreground fg4 :box bg2)))
                (mini-modeline-mode-line :inherit mode-line :height 0.1 :box nil)
+               ;; header-line
+               (header-line :inherit 'mode-line)
+               (header-line-highlight :inherit 'mode-line-highlight)
                ;; mu4e
                (mu4e-unread-face :foreground ,dracula-pink :weight normal)
                (mu4e-view-url-number-face :foreground ,dracula-purple)


### PR DESCRIPTION
I would like to add faces to support header-line to have a good view. I study from [doom-themes-base.el#L56](https://github.com/hlissner/emacs-doom-themes/blob/96edc0ceb864b7d72218e58c8e9272cd96e5712c/doom-themes-base.el#L56)

## Before

![before](https://user-images.githubusercontent.com/9713793/184916573-2ec9e0fe-f066-44ae-9007-433a9455a6ce.png)
## After

![after](https://user-images.githubusercontent.com/9713793/184916617-0baa18db-04ff-4151-860d-23445b60e88f.png)
