### PR TITLE
add bookmark-face for emacs@28.1+

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -161,6 +161,8 @@ read it before opening a new issue about your will.")
                (font-lock-warning-face :inherit warning :background ,bg2)
                ;; auto-complete
                (ac-completion-face :underline t :foreground ,dracula-pink)
+               ;; bookmarks
+               (bookmark-face :foreground ,dracula-pink)
                ;; company
                (company-echo-common :foreground ,dracula-bg :background ,dracula-fg)
                (company-preview :background ,dracula-current :foreground ,other-blue)


### PR DESCRIPTION
emacs@28.1 adds a new fringe mark for bookmarks. I ran into when viewing org files after running `org-capture`.

🤖 Emacs default:
![Screen Shot 2023-01-05 at 11 17 22 AM](https://user-images.githubusercontent.com/971616/210832562-0a44ebb8-4690-4d88-a543-788a68d3ba38.png)

🧛 Vampirized:
![Screen Shot 2023-01-05 at 11 21 15 AM](https://user-images.githubusercontent.com/971616/210832577-3c8eb39b-316c-423c-8cde-772dbbff1f60.png)

**Question:** is pink the right color for this? 
