### PR TITLE
Add `solaire-mode` basic support

### DIFF
--- a/dracula-theme.el
+++ b/dracula-theme.el
@@ -882,6 +882,8 @@ read it before opening a new issue about your will.")
                (shr-h6 :foreground ,dracula-orange)
                ;; slime
                (slime-repl-inputed-output-face :foreground ,dracula-purple)
+               ;; solaire-mode
+               (solaire-default-face :background ,bg2)
                ;; spam
                (spam :inherit gnus-summary-normal-read :foreground ,dracula-orange
                      :strike-through t :slant oblique)


### PR DESCRIPTION
This adds a new face used by [solaire-mode](https://github.com/hlissner/emacs-solaire-mode).

![image](https://github.com/dracula/emacs/assets/2318843/3e14267a-4479-405c-a14a-fe7d3d1828a1)
